### PR TITLE
Update to support more recent Lita versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.0.0
+  - 2.1
+  - 2.2
 script: bundle exec rake
 before_install:
   - gem update --system

--- a/lib/lita-high-five.rb
+++ b/lib/lita-high-five.rb
@@ -1,1 +1,12 @@
+require "lita"
+
+Lita.load_locales Dir[File.expand_path(
+  File.join("..", "..", "locales", "*.yml"), __FILE__
+)]
+
 require "lita/handlers/high_five"
+
+Lita::Handlers::HighFive.template_root File.expand_path(
+  File.join("..", "..", "templates"),
+ __FILE__
+)

--- a/lib/lita/handlers/high_five.rb
+++ b/lib/lita/handlers/high_five.rb
@@ -1,5 +1,3 @@
-require "lita"
-
 module Lita
   module Handlers
     class HighFive < Handler
@@ -18,7 +16,3 @@ module Lita
     Lita.register_handler(HighFive)
   end
 end
-
-Lita.load_locales Dir[File.expand_path(
-  File.join("..", "..", "..", "..", "locales", "*.yml"), __FILE__
-)]

--- a/lita-high-five.gemspec
+++ b/lita-high-five.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-high-five"
-  spec.version       = "0.1.0"
+  spec.version       = "1.0.0"
   spec.authors       = ["Jimmy Cuadra"]
   spec.email         = ["jimmy@jimmycuadra.com"]
   spec.description   = %q{A Lita handler that won't leave you hanging.}

--- a/lita-high-five.gemspec
+++ b/lita-high-five.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-high-five"
-  spec.version       = "0.0.1"
+  spec.version       = "0.1.0"
   spec.authors       = ["Jimmy Cuadra"]
   spec.email         = ["jimmy@jimmycuadra.com"]
   spec.description   = %q{A Lita handler that won't leave you hanging.}
@@ -14,11 +14,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 3.0"
+  spec.add_runtime_dependency "lita", ">= 4.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 3.0.0.beta2"
+  spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "rspec", ">= 3.0.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
 end


### PR DESCRIPTION
Will fix help message:

```
translation missing: en-US.UTF-8.lita.handlers.high_five.help.high_five_value
```
